### PR TITLE
14 implement runCommand()

### DIFF
--- a/src/main/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServer.java
+++ b/src/main/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServer.java
@@ -91,9 +91,14 @@ public class ContinuousIntegrationServer extends AbstractHandler
 
 	try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
 		StringBuilder stringBuilder = new StringBuilder();
-		int character;
-		while ((character = bufferedReader.read()) != -1) {
-			stringBuilder.append((char) character);
+		String line;
+		boolean firstLine = true;
+		while ((line = bufferedReader.readLine()) != null) {
+			if (!firstLine) {
+					stringBuilder.append("\n");
+			}
+			stringBuilder.append(line);
+			firstLine = false;
 		}
 		process.waitFor();
 		String output = stringBuilder.toString();

--- a/src/test/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServerTest.java
+++ b/src/test/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServerTest.java
@@ -25,7 +25,7 @@ public class ContinuousIntegrationServerTest {
 		File directory = new File("./");
 		List<String> command = List.of("echo", "Testing");
 		String output = continuousIntegrationServer.runCommand(command, directory);
-		assertEquals("Testing", output.trim());
+		assertEquals("Testing", output);
 	}
 
 	/**


### PR DESCRIPTION
I chose to read character by character instead of line by line since bufferedReader.readLine() removes newlines which I think we will want to keep for the build logs. 

I also assume that everyone runs this server on a unix-like OS, if this is not the case please let me know, I guess we can add it as a dependency/prerequisite to the README.md