### PR TITLE
feat: implement gitClone method

### DIFF
--- a/src/main/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServer.java
+++ b/src/main/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServer.java
@@ -6,6 +6,7 @@ import javax.servlet.ServletException;
  
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.util.List;
 import java.io.BufferedReader;
 import java.io.File;
@@ -108,8 +109,18 @@ public class ContinuousIntegrationServer extends AbstractHandler
 	}
     }
 
-    void gitClone(String url) {
-        return;
+
+    /**
+     * Clones git repository into a temporary directory
+     *
+     * @param url The url of the repository
+     * @return directory The temporary directory containing the repo
+     */
+    File gitClone(String url) throws IOException, InterruptedException {
+		File directory = Files.createTempDirectory("repository").toFile();
+		List<String> command = List.of("git", "clone", url);
+		runCommand(command, directory);
+		return directory;
     }
 
     void removeGitDir() {

--- a/src/test/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServerTest.java
+++ b/src/test/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServerTest.java
@@ -2,6 +2,7 @@ package io.github.dd2480group14.ciserver;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,5 +41,21 @@ public class ContinuousIntegrationServerTest {
 		File directory = new File("./");
 		List<String> command = List.of("Fakecommand");
 		assertThrows(IOException.class, () -> continuousIntegrationServer.runCommand(command, directory));
+	}
+
+	/**
+	 * Clones a git repository and
+	 * verifies that the .git directory
+	 * exists
+	 */
+	@Test
+	public void runGitClone() throws IOException, InterruptedException {
+		ContinuousIntegrationServer continuousIntegrationServer = new ContinuousIntegrationServer();
+		String url = "https://github.com/octocat/Hello-World.git";
+		String repositoryName = "Hello-World";
+		File tempDirectory = continuousIntegrationServer.gitClone(url);
+		File repositoryFolder = new File(tempDirectory, repositoryName);
+		boolean gitFolderExists = new File(repositoryFolder, ".git").exists();
+		assertTrue(gitFolderExists);
 	}
 }


### PR DESCRIPTION
The method uses createTempDirectory which create a unique directory in /tmp/

We could then extract the repository name from the github webhook and easily construct the file path to repo which then can be used to resolve following issues:

https://github.com/DD2480-Group-14/Assignment2-Continuous-Integration/issues/9
https://github.com/DD2480-Group-14/Assignment2-Continuous-Integration/issues/8
