### PR TITLE
feat: Implement method that safely removes temporary directory

### DIFF
--- a/src/main/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServer.java
+++ b/src/main/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServer.java
@@ -7,10 +7,14 @@ import javax.servlet.ServletException;
 import java.io.*;
 
 import java.util.Scanner;
+import java.util.stream.Stream;
+import java.util.Comparator;
 import java.util.List;
 
 import java.nio.file.Files;
- 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.AbstractHandler;
@@ -148,8 +152,34 @@ public class ContinuousIntegrationServer extends AbstractHandler {
 		return directory;
     }
 
-    void removeGitDir() {
-        return;
+    /**
+     * Recursively removes specified directory, 
+     * subfiles and subdirectories if located in
+     * the system's tmp directory
+     *
+     * @param directory The directory to remove 
+     */
+    void removeDirectoryInTmp(File directory) throws IOException {
+		Path verifiedDirectoryPath = getVerifiedPath(directory);
+		try ( Stream<Path> paths = Files.walk(verifiedDirectoryPath)) {
+				for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) {
+					Files.delete(path);
+				}
+		};
+    }
+
+    private Path getVerifiedPath(File directory) throws IllegalArgumentException, IOException {
+		if (directory == null || !directory.exists()) {
+				throw new IllegalArgumentException("Directory does not exists");
+		}
+		Path directoryPath = directory.toPath().toRealPath();
+		Path systemTmpPath = Paths.get(System.getProperty("java.io.tmpdir")).toRealPath();
+		if (!directoryPath.startsWith(systemTmpPath)) {
+				throw new IllegalArgumentException(
+					String.format("Only allowed to remove directories in %s", systemTmpPath)
+				);
+		}
+		return directoryPath;
     }
 
     String runTests(File dir) {

--- a/src/test/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServerTest.java
+++ b/src/test/java/io/github/dd2480group14/ciserver/ContinuousIntegrationServerTest.java
@@ -1,15 +1,14 @@
 package io.github.dd2480group14.ciserver;
 
 import java.io.*;
-
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -105,6 +104,41 @@ public class ContinuousIntegrationServerTest {
 		File repositoryFolder = new File(tempDirectory, repositoryName);
 		boolean gitFolderExists = new File(repositoryFolder, ".git").exists();
 		assertTrue(gitFolderExists);
+	}
+
+	/**
+	 * Creates a temporary directory with
+	 * a file one level down. Verifies
+	 * that both the directory and file
+	 * is removed
+	 */
+	@Test
+	public void removeDirectoryAndSubfileInTmp() throws IOException, InterruptedException {
+		ContinuousIntegrationServer continuousIntegrationServer = new ContinuousIntegrationServer();
+		File directory = Files.createTempDirectory("test").toFile();
+		String testFileName = "test.py";
+		File testFile = new File(directory, testFileName);
+		List<String> createFileCommand = List.of("touch", testFileName);
+		continuousIntegrationServer.runCommand(createFileCommand, directory);
+		assertTrue(directory.exists());
+		assertTrue(testFile.exists());
+		continuousIntegrationServer.removeDirectoryInTmp(directory);
+		assertFalse(directory.exists());
+		assertFalse(testFile.exists());
+	}
+
+	/**
+	 * Try to remove root of project
+	 * should fail because its outside
+	 * of the system's temporary folder
+	 */
+	@Test
+	public void removeDirectoryOutsideOfTmp() throws IOException, InterruptedException {
+		ContinuousIntegrationServer continuousIntegrationServer = new ContinuousIntegrationServer();
+		File directory = new File("./");
+		assertTrue(directory.exists());
+		assertThrows(IllegalArgumentException.class, () -> continuousIntegrationServer.removeDirectoryInTmp(directory));
+		assertTrue(directory.exists());
 	}
 }
 


### PR DESCRIPTION
Tried to do this as safely as possible so that we dont accidentally removes root or something else important. 

If we have the time in the future we could/should investigate using only java.nio instead of java.io.

Closes #9 